### PR TITLE
Fix test, and reduce warning noise from geo-polygon update

### DIFF
--- a/lib/arelastic/queries/geo_polygon.rb
+++ b/lib/arelastic/queries/geo_polygon.rb
@@ -1,20 +1,20 @@
 module Arelastic
   module Queries
     class GeoPolygon < Arelastic::Queries::Query
-      warn 'Arelastic::Queries::GeoPolygon is deprecated in Elastic Search 7.12;'
-      + 'Use Arelastic::Queries::GeoShape instead.'
-
       attr_accessor :field, :points, :options
+
       def initialize(field, points, options = {})
+        warn 'Arelastic::Queries::GeoPolygon is deprecated in Elastic Search 7.12;'
+        + 'Use Arelastic::Queries::GeoShape instead.'
         @field   = field
         @points  = points
         @options = options
       end
 
       def as_elastic
-        params = {field => {"points" => points}}.update(options)
+        params = { field => { 'points' => points } }.update(options)
 
-        { "geo_polygon" => params }
+        { 'geo_polygon' => params }
       end
     end
   end

--- a/test/arelastic/builders/sort_test.rb
+++ b/test/arelastic/builders/sort_test.rb
@@ -1,5 +1,17 @@
 require 'helper'
 
 class Arelastic::Builders::SortTest < Minitest::Test
-  
+  def test_asc
+    query = Arelastic::Builders::Sort['field'].asc
+    expected = { 'field' => 'asc' }
+
+    assert_equal expected, query.as_elastic
+  end
+
+  def test_desc
+    query = Arelastic::Builders::Sort['field'].desc
+    expected = { 'field' => 'desc' }
+
+    assert_equal expected, query.as_elastic
+  end
 end

--- a/test/arelastic/queries/geo_shape/polygon_test.rb
+++ b/test/arelastic/queries/geo_shape/polygon_test.rb
@@ -8,9 +8,14 @@ class Arelastic::Queries::GeoShape::PolygonTest < Minitest::Test
       [-123.84, 46.15]
     ]
     expected = {
-      'person.location' => {
-        'type' => 'Polygon',
-        'coordinates' => points
+      'geo_shape' => {
+        'person.location' => {
+          'shape' => {
+            'type' => 'polygon',
+            'coordinates' => [points]
+          },
+          'relation' => 'within'
+        }
       }
     }
 


### PR DESCRIPTION
Move the warning for `GeoPolygon` into the initialize function to reduce noise in other repositories. 
Fix the `GeoShape::Polygon` test
Add tests for sort so we meet the coverage requirements in the repository.