### PR TITLE
Make `as_elastic` idempotent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 gem 'rake'
 gem 'minitest'
 gem 'simplecov', require: false
+gem 'debug'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ gemspec
 gem 'rake'
 gem 'minitest'
 gem 'simplecov', require: false
-gem 'debug'

--- a/lib/arelastic/queries/bool.rb
+++ b/lib/arelastic/queries/bool.rb
@@ -35,8 +35,9 @@ module Arelastic
         mergeable, other = expr.partition { |el| el.is_a?(klass) }
         merged = mergeable.group_by(&merge_test_method).flat_map do |_, group|
           if group.size > 1
-            group.first.instance_variable_set("@query", self.class.new(clause => group.map(&:query)))
-            group.first
+            item = group.first.dup
+            item.instance_variable_set("@query", self.class.new(clause => group.map(&:query)))
+            item
           else
             group
           end

--- a/test/arelastic/queries/bool_test.rb
+++ b/test/arelastic/queries/bool_test.rb
@@ -18,15 +18,22 @@ class Arelastic::Queries::BoolTest < Minitest::Test
   #   assert_equal expected, filtered.as_elastic
   # end
 
-  def test_idempotent_with_duplicate_nested
-    nested = Arelastic::Queries::Nested.new('contacts',
+  def test_as_elastic_with_nested_is_idempotent
+    nested1 = Arelastic::Queries::Nested.new('contacts',
       {
         'terms' => {
           'contacts.title_codes' => { 'query' => ['1'] }
         }
       }
     )
-    query = Arelastic::Queries::Bool.new(must: [nested, nested])
+    nested2 = Arelastic::Queries::Nested.new('contacts',
+      {
+        'terms' => {
+          'contacts.first_name' => { 'query' => ['Matthew'] }
+        }
+      }
+    )
+    query = Arelastic::Queries::Bool.new(must: [nested1, nested2])
 
     assert_equal query.as_elastic, query.as_elastic
   end

--- a/test/arelastic/queries/bool_test.rb
+++ b/test/arelastic/queries/bool_test.rb
@@ -18,6 +18,19 @@ class Arelastic::Queries::BoolTest < Minitest::Test
   #   assert_equal expected, filtered.as_elastic
   # end
 
+  def test_idempotent_with_duplicate_nested
+    nested = Arelastic::Queries::Nested.new('contacts',
+      {
+        'terms' => {
+          'contacts.title_codes' => { 'query' => ['1'] }
+        }
+      }
+    )
+    query = Arelastic::Queries::Bool.new(must: [nested, nested])
+
+    assert_equal query.as_elastic, query.as_elastic
+  end
+
   def test_as_elastic
     bool = Arelastic::Queries::Bool.new(
       must: {


### PR DESCRIPTION
## Context

Parallel `nested`, `has_child`, and `has_parent` queries get merged such that there is only 1 of each of these types of query per level. This is done for [performance reasons](https://github.com/data-axle/arelastic/commit/fcc347e5589b738991bcdc747721b40cc317e7e5).

## Problem

When `as_elastic` is called, one of the nested/join nodes get the queries of the others copied underneath it, but the others will still remain. This is done without a `dup` or `clone` call, so process repeats with each subsequent call to `as_elastic`, with the result being an ever-growing monstrosity of a query with lots of redundant expressions:

<details>
<summary> Repetitive monster query </summary>

```
{
  "query": {
    "bool": {
      "filter": {
        "bool": {
          "must": [
            {
              "term": {
                "type_of_document": "place"
              }
            },
            {
              "bool": {
                "must": [
                  {
                    "nested": {
                      "path": "contacts",
                      "query": {
                        "bool": {
                          "must": [
                            {
                              "bool": {
                                "must": [
                                  {
                                    "bool": {
                                      "must": [
                                        {
                                          "bool": {
                                            "must": [
                                              {
                                                "bool": {
                                                  "must": [
                                                    {
                                                      "bool": {
                                                        "must": [
                                                          {
                                                            "bool": {
                                                              "must": [
                                                                {
                                                                  "bool": {
                                                                    "must": [
                                                                      {
                                                                        "bool": {
                                                                          "must": [
                                                                            {
                                                                              "terms": {
                                                                                "contacts.title_codes": [
                                                                                  "1"
                                                                                ]
                                                                              }
                                                                            }
                                                                          ]
                                                                        }
                                                                      },
                                                                      {
                                                                        "terms": {
                                                                          "contacts.title_codes": [
                                                                            "1"
                                                                          ]
                                                                        }
                                                                      }
                                                                    ]
                                                                  }
                                                                },
                                                                {
                                                                  "terms": {
                                                                    "contacts.title_codes": [
                                                                      "1"
                                                                    ]
                                                                  }
                                                                }
                                                              ]
                                                            }
                                                          },
                                                          {
                                                            "terms": {
                                                              "contacts.title_codes": [
                                                                "1"
                                                              ]
                                                            }
                                                          }
                                                        ]
                                                      }
                                                    },
                                                    {
                                                      "terms": {
                                                        "contacts.title_codes": [
                                                          "1"
                                                        ]
                                                      }
                                                    }
                                                  ]
                                                }
                                              },
                                              {
                                                "terms": {
                                                  "contacts.title_codes": [
                                                    "1"
                                                  ]
                                                }
                                              }
                                            ]
                                          }
                                        },
                                        {
                                          "terms": {
                                            "contacts.title_codes": [
                                              "1"
                                            ]
                                          }
                                        }
                                      ]
                                    }
                                  },
                                  {
                                    "terms": {
                                      "contacts.title_codes": [
                                        "1"
                                      ]
                                    }
                                  }
                                ]
                              }
                            },
                            {
                              "terms": {
                                "contacts.title_codes": [
                                  "1"
                                ]
                              }
                            }
                          ]
                        }
                      }
                    }
                  }
                ]
              }
            }
          ]
        }
      }
    }
  }
}
```
</details>

## Solution

Call `dup` on the node that's receiving the other nested/join queries underneath it. Thus, `as_elastic` is idempotent.